### PR TITLE
Fix issue with cache on fast growing repositories

### DIFF
--- a/common/src/main/java/digilib/io/BaseDirDocuDirectory.java
+++ b/common/src/main/java/digilib/io/BaseDirDocuDirectory.java
@@ -28,6 +28,7 @@ package digilib.io;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 
 import digilib.conf.DigilibConfiguration;
 import digilib.io.FileOps.FileClass;
@@ -83,6 +84,13 @@ public class BaseDirDocuDirectory extends FsDocuDirectory {
 		}
 		// read all filenames
 		logger.debug("reading directory " + this + " = " + dir.dir.getPath());
+		// set our read time to the end of the previous second so that we will not miss
+		// changes occurred at the same time than our reading due to the accuracy of the filesystem timestamp
+		dirMTime = (new Date().getTime()  / 1000) * 1000 - 1;
+
+		// read metadata as well
+		readMeta();
+
 		File[] allFiles = null;
 		/*
 		 * using ReadableFileFilter is safer (we won't get directories with file
@@ -139,9 +147,6 @@ public class BaseDirDocuDirectory extends FsDocuDirectory {
 				d.clearFilenames();
 			}
 		}
-		dirMTime = dir.dir.lastModified();
-		// read metadata as well
-		readMeta();
 		return isValid;
     }
 


### PR DESCRIPTION
We hit this issue when a process were adding lot of images in the same subfolder of the digilib directory requesting the image just after having added it (in our case using a symblink so the process was also faster). When the read occur in the same second than the previous successful read digilib report a wrong 404.

For example having 10 images
at time 0sec we put image 1 in digilib and request a small thumbnail of it
few ms after we put image 2 in digilib, the request to get a thumbnail fails with a 404
at time 1sec we repeat the request and the thumbnail is successful generated

The idea of the patch is to store the read time (truncated to the sec accuracy) instead than the last modified time reported by the filesystem to check future validity of the cache