### PR TITLE
Resolves #35. Use current application directory for path resolution.

### DIFF
--- a/servlet/src/main/java/digilib/conf/DigilibServletConfiguration.java
+++ b/servlet/src/main/java/digilib/conf/DigilibServletConfiguration.java
@@ -198,10 +198,9 @@ public class DigilibServletConfiguration extends DigilibConfiguration implements
         String fn = c.getInitParameter("config-file");
         if (fn == null) {
             logger.debug("readConfig: no param config-file");
-            fn = ServletOps.getConfigFileName("digilib-config.xml", c);
-            if (fn == null) fn = "";
+            fn = "./WEB-INF/digilib-config.xml";
         }
-        File f = new File(fn);
+        File f = ServletOps.getFile(new File(fn), c);
         if (f.canRead()) {
             // setup config file list reader
             XMLMapLoader lilo = new XMLMapLoader("digilib-config", "parameter", "name", "value");
@@ -235,10 +234,7 @@ public class DigilibServletConfiguration extends DigilibConfiguration implements
                 logger.warn("No digilib config file! Using defaults!");
                 // update basedir-list
                 String[] dirs = (String[]) this.getValue("basedir-list");
-                for (int j = 0; j < dirs.length; j++) {
-                    // make relative directory paths be inside the webapp
-                    dirs[j] = ServletOps.getFile(dirs[j], c);
-                }
+                this.expandBaseDirList(dirs, c);
             }
         }
 
@@ -269,10 +265,7 @@ public class DigilibServletConfiguration extends DigilibConfiguration implements
                     if (confEntry.getKey().equals("basedir-list")) {
                         // split list into directories
                         String[] dirs = FileOps.pathToArray(confEntry.getValue());
-                        for (int j = 0; j < dirs.length; j++) {
-                            // make relative directory paths be inside the webapp
-                            dirs[j] = ServletOps.getFile(dirs[j], ctx);
-                        }
+                        this.expandBaseDirList(dirs, ctx);
                         if (dirs != null) {
                             param.setValue(dirs);
                         }
@@ -460,6 +453,16 @@ public class DigilibServletConfiguration extends DigilibConfiguration implements
      */
     protected DigilibServletConfiguration getContextConfig(ServletContext context) {
         return getCurrentConfig(context);
+    }
+
+    /**
+     * Resolve all paths in the basedir-list.
+     * See {@link ServletOps#getFile(File, ServletContext)} for resolution logic.
+     */
+    private void expandBaseDirList(String[] dirs, ServletContext c) {
+        for (int j = 0; j < dirs.length; j++) {
+            dirs[j] =  ServletOps.getFile(new File(dirs[j]), c).getPath();
+        }
     }
 
 }

--- a/servlet/src/main/java/digilib/servlet/ServletOps.java
+++ b/servlet/src/main/java/digilib/servlet/ServletOps.java
@@ -121,35 +121,16 @@ public class ServletOps {
     public static File getFile(File f, ServletContext sc) {
         // is the filename absolute?
         if (!f.isAbsolute()) {
-            // relative path -> use getRealPath to resolve in WEB-INF
             String fn = sc.getRealPath("/" + f.getPath());
-            if (fn == null) {
-                // TODO: use getResourceAsStream?
-                return null;
+            if (fn != null && new File(fn).exists()) {
+                // relative path -> use getRealPath to resolve in WEB-INF
+                f = new File(fn);
             }
-            f = new File(fn);
+            // but if relative path can't be resolved inside webapp we
+            // assume that it is relative to user working directory,
+            // so we return it as.
         }
         return f;
-    }
-
-    /**
-     * get a real file name for a web app file pathname.
-     * 
-     * If filename starts with "/" its treated as absolute else the path is
-     * appended to the base directory of the web-app.
-     * 
-     * @param filename the filename
-     * @param sc the ServletContext
-     * @return the filename
-     */
-    public static String getFile(String filename, ServletContext sc) {
-        File f = new File(filename);
-        // is the filename absolute?
-        if (!f.isAbsolute()) {
-            // relative path -> use getRealPath to resolve in WEB-INF
-            filename = sc.getRealPath("/" + filename);
-        }
-        return filename;
     }
 
     /**
@@ -183,26 +164,6 @@ public class ServletOps {
         }
         f = new File(newfn);
         return f;
-    }
-
-    /**
-     * get a real file name for a config file pathname.
-     * 
-     * If filename starts with "/" its treated as absolute else the path is
-     * appended to the WEB-INF directory of the web-app.
-     * 
-     * @param filename the filename
-     * @param sc the ServletContext
-     * @return the filename
-     */
-    public static String getConfigFileName(String filename, ServletContext sc) {
-        File f = new File(filename);
-        // is the filename absolute?
-        if (!f.isAbsolute()) {
-            // relative path -> use getRealPath to resolve in WEB-INF
-            filename = sc.getRealPath("/WEB-INF/" + filename);
-        }
-        return filename;
     }
 
     /**


### PR DESCRIPTION
This change is backward compatible.

In case of relative path first try to resolve it against ServletContext, but if the path doesn't exist fallback to default java behavior of using current application directory.

Applicable to basedir-list and config location path resolution.