### PR TITLE
add support for reading and writing webp

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -108,5 +108,10 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.usefulness</groupId>
+      <artifactId>webp-imageio</artifactId>
+      <version>0.10.2</version>
+    </dependency>
   </dependencies>
 </project>

--- a/common/src/main/java/digilib/conf/DigilibOption.java
+++ b/common/src/main/java/digilib/conf/DigilibOption.java
@@ -113,6 +113,10 @@ public enum DigilibOption {
 	 */
 	png,
 	/**
+	 * the resulting image is always sent as webp
+	 */
+	webp,
+	/**
 	 * interpret wx, wy, ww, wh as pixel coordinates on the highest resolution
 	 * image.
 	 */

--- a/common/src/main/java/digilib/conf/DigilibRequest.java
+++ b/common/src/main/java/digilib/conf/DigilibRequest.java
@@ -686,6 +686,9 @@ public class DigilibRequest extends ParameterMap {
             } else if (format.equals("png")) {
                 // force png
                 options.setOption(DigilibOption.png);
+            } else if (format.equals("webp")) {
+                // force webp
+                options.setOption(DigilibOption.webp);
             } else {
                 errorMessage = "Invalid format parameter in IIIF path!";
                 logger.error(errorMessage);

--- a/common/src/main/java/digilib/image/DocuImage.java
+++ b/common/src/main/java/digilib/image/DocuImage.java
@@ -79,7 +79,7 @@ public interface DocuImage {
      * The image is encoded to the mime-type <code>mt</code> and sent to the
      * output stream <code>ostream</code>.
      * 
-     * Currently only mime-types "image/jpeg" and "image/png" are supported.
+     * Currently only mime-types "image/jpeg", "image/png" and "image/webp" are supported.
      * 
      * @param mt
      *            mime-type of the image to be sent.

--- a/common/src/main/java/digilib/image/ImageJobDescription.java
+++ b/common/src/main/java/digilib/image/ImageJobDescription.java
@@ -522,6 +522,8 @@ public class ImageJobDescription {
             return "image/jpeg";
         } else if (request.hasOption(DigilibOption.png)) {
             return "image/png";
+        } else if (request.hasOption(DigilibOption.webp)) {
+            return "image/webp";
         }
         // use input image type
         try {

--- a/common/src/main/java/digilib/image/ImageLoaderDocuImage.java
+++ b/common/src/main/java/digilib/image/ImageLoaderDocuImage.java
@@ -855,6 +855,11 @@ public class ImageLoaderDocuImage extends ImageInfoDocuImage {
                 logger.debug("ImageIO: writer: {}", writer.getClass());
                 writer.setOutput(imgout);
                 writePng(writer);
+            } else if (mt == "image/webp") {
+                writer = getWriter(mt);
+                logger.debug("ImageIO: writer: {}", writer.getClass());
+                writer.setOutput(imgout);
+                writeWebp(writer);
             } else {
                 // unknown mime type
                 throw new ImageOpException("Unknown output mime type: " + mt);
@@ -953,6 +958,18 @@ public class ImageLoaderDocuImage extends ImageInfoDocuImage {
         }
         // render output
         logger.debug("writing JPEG");
+        writer.write(null, new IIOImage(img, null, null), param);
+    }
+
+    /**
+     * Write the current image to the given ImageWriter as WEBP.
+     *
+     * @param writer
+     * @throws IOException
+     */
+    protected void writeWebp(ImageWriter writer) throws IOException {
+        ImageWriteParam param = writer.getDefaultWriteParam();
+        logger.debug("writing WEBP");
         writer.write(null, new IIOImage(img, null, null), param);
     }
 


### PR DESCRIPTION
This MR adds webp support to digilib-common (https://github.com/robcast/digilib/issues/66). I tested it with  https://gitlab.gwdg.de/dariah-de/dariah-de-digilib-services. I am unsure whether to put the dependency on webp-imageio into a maven profile, as the code would then fail on runtime. Also I did not look into color profiles, I have seen code for it in PNG and JPG writing code. I could also look into this, but have no experience how to test this.

